### PR TITLE
venv in-project

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,4 +16,5 @@ RUN apt-get install -y nodejs
 ENV POETRY_HOME=/opt/poetry
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - && \
 	cd /usr/local/bin && \
-	ln -s /opt/poetry/bin/poetry
+	ln -s /opt/poetry/bin/poetry && \
+	poetry config virtualenvs.in-project true


### PR DESCRIPTION
# 課題

`docker-compose up` するたびに毎回poetryのインストールが走っていて重かった

# アプローチ

プロジェクトディレクトリにvenvを作るようにした。

これで、dockerコンテナ内のpoetryが参照するvenvが永続化されるので、一度作ってしまって変更なければ、再度のインストールが走らない。

# 影響

プロジェクトのルートディレクトリに `.venv` が作成される。

ローカルでpoetry使う時にバッティングする？？？試してない。けど、docker使うので基本はコンテナで作業するから問題ないのではないか？？
